### PR TITLE
Added register until successful for OpenJDK PPA

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -41,6 +41,8 @@
     repo: ppa:openjdk-r/ppa
     state: present
   become: true
+  register: result
+  until: result is successful
   when: ansible_distribution == "Ubuntu"
 
 - name: debian | Installing Java


### PR DESCRIPTION
Hit this today where a single timeout failed out.